### PR TITLE
Fix event response data type

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {
   defaultGasLimit
 } = require('./config.json')
 const erc20ABI = require('./erc20-abi.json')
+const BigNumber = require('bignumber.js')
 
 const web3 = new Web3(infuraEndpoint)
 const erc20 = new web3.eth.Contract(erc20ABI, erc20Address)
@@ -15,8 +16,8 @@ const erc20 = new web3.eth.Contract(erc20ABI, erc20Address)
 const BN = web3.utils.toBN
 const decimalBN = BN(10).pow(BN(erc20Decimal))
 
-const convertValue = value => BN(value).div(decimalBN).toString(10)
-const convertToValue = value => BN(value).mul(decimalBN)
+const convertValue = value => BigNumber(value).dividedBy(decimalBN).toString(10)
+const convertToValue = value => BigNumber(value).multipliedBy(decimalBN)
 const dep = { MESG, web3, erc20, convertValue, convertToValue, blockConfirmations, defaultGasLimit }
 const tasksHandler = require('./tasks')
 const signTxHandler = require('./tasks/signTxHandler')(dep)

--- a/mesg.yml
+++ b/mesg.yml
@@ -24,7 +24,7 @@ events:
       value:
         name: "Value"
         description: "Value of the approval"
-        type: Number
+        type: String
   transfer:
     name: "Transfer"
     description: "The transfer event of the ERC20. This event happens when a transfer occurred."
@@ -48,7 +48,7 @@ events:
       value:
         name: "Value"
         description: "Value of the approval"
-        type: Number
+        type: String
 tasks:
   totalSupply:
     name: "Total supply"

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -2529,14 +2534,6 @@
         "mime-types": "~2.1.18"
       }
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -2868,8 +2865,19 @@
       "integrity": "sha1-fecPG4Py3jZHZ3IVa+z+9uNRbrM=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.34",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+        "web3-core-helpers": "1.0.0-beta.34"
+      },
+      "dependencies": {
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -2902,16 +2910,6 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
         }
-      }
-    },
-    "websocket": {
-      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-      "requires": {
-        "debug": "^2.2.0",
-        "nan": "^2.3.3",
-        "typedarray-to-buffer": "^3.1.2",
-        "yaeti": "^0.0.6"
       }
     },
     "window-size": {
@@ -2990,11 +2988,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-    },
-    "yaeti": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yargs": {
       "version": "3.32.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/mesg-foundation/service-ethereum-erc20#readme",
   "dependencies": {
+    "bignumber.js": "^7.2.1",
     "mesg-js": "^1.2.1",
     "web3": "^1.0.0-beta.34"
   }


### PR DESCRIPTION
Fix #10 

-----

Due to from the [code](https://github.com/mesg-foundation/service-ethereum-erc20/blob/master/index.js#L18)
```js
const convertValue = value => BN(value).div(decimalBN).toString(10)
```
and the type defined on [mesg.yml](https://github.com/mesg-foundation/service-ethereum-erc20/blob/master/mesg.yml#L51) should be the same type as `String`. also the value returned from `erc20.getPastEvents` [function](https://github.com/mesg-foundation/service-ethereum-erc20/blob/master/events/index.js#L17) is string.