### PR TITLE
Do not stop the polling on error

### DIFF
--- a/events/index.js
+++ b/events/index.js
@@ -52,23 +52,21 @@ module.exports = ({
 
   var previousBN
   const pollingBlockNumber = async () => {
-    const lastBN = await web3.eth.getBlockNumber()
-    const shiftedBN = lastBN - parseInt(process.env.BLOCK_CONFIRMATIONS, 10)
-    if (previousBN === undefined) {
-      previousBN = shiftedBN - 1
-    }
-    if (shiftedBN > previousBN) {
-      console.log('new block', shiftedBN)
-      await fetchEvents(previousBN, shiftedBN)
-      previousBN = shiftedBN
-    }
-    return setTimeout(async () => {
-      try {
-        await pollingBlockNumber()
-      } catch (err) {
-        console.error(err)
+    try {
+      const lastBN = await web3.eth.getBlockNumber()
+      const shiftedBN = lastBN - parseInt(process.env.BLOCK_CONFIRMATIONS, 10)
+      if (previousBN === undefined) {
+        previousBN = shiftedBN - 1
       }
-    }, 1000)
+      if (shiftedBN > previousBN) {
+        console.log('new block', shiftedBN)
+        await fetchEvents(previousBN, shiftedBN)
+        previousBN = shiftedBN
+      }
+    } catch (error) {
+      console.log(error)
+    }
+    return setTimeout(pollingBlockNumber, 1000)
   }
   return pollingBlockNumber()
 }


### PR DESCRIPTION
When one of the fetch was not working for any reason (eg: cannot access the node) the polling was stopped and the program wasn't doing anything more.

2 solutions here: crash the process and let docker restart it or continue the polling.

I choose to continue the polling. We already make sure to receive the logs even if we missed one block so we can delay the polling until it work.

We could later add a max retry count to crash the process if there is too much retries